### PR TITLE
Clarify refresh token verification docstring

### DIFF
--- a/server/backend/app/services/authentication.py
+++ b/server/backend/app/services/authentication.py
@@ -151,8 +151,7 @@ async def verify_refresh_token(token: str, db: AsyncSession) -> Optional[Refresh
         db (AsyncSession): The database session used to query the refresh token.
 
     Returns:
-        Optional[RefreshToken]: The corresponding RefreshToken object if the token is valid,
-        or None if the token is invalid.
+        RefreshToken: The corresponding RefreshToken object if the token is valid.
 
     Raises:
         HTTPException: If the token is invalid, revoked, expired, or not found in the database.


### PR DESCRIPTION
## Summary
- clarify verify_refresh_token docstring to always return RefreshToken and mention HTTPException on failure

## Testing
- `pytest` *(fails: 1 failed, 17 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689e2abdf4588321a53d56e19304b543