### PR TITLE
test: enforce empty field validation

### DIFF
--- a/server/backend/app/schemas/client_auth.py
+++ b/server/backend/app/schemas/client_auth.py
@@ -1,15 +1,15 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ClientEnrollRequest(BaseModel):
-    username: str
-    password: str
-    client_version: str
+    username: str = Field(..., min_length=1)
+    password: str = Field(..., min_length=1)
+    client_version: str = Field(..., min_length=1)
 
 
 class ClientLoginRequest(BaseModel):
-    username: str
-    password: str
+    username: str = Field(..., min_length=1)
+    password: str = Field(..., min_length=1)
 
 
 class TokenResponse(BaseModel):

--- a/server/backend/tests/unit/test_routers/test_client_auth.py
+++ b/server/backend/tests/unit/test_routers/test_client_auth.py
@@ -94,17 +94,19 @@ async def test_client_enroll_missing_client_version(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_client_enroll_empty_fields(client: AsyncClient):
+@pytest.mark.parametrize(
+    "enroll_data",
+    [
+        {"username": "", "password": "testpassword123", "client_version": "1.0.0"},
+        {"username": "testuser", "password": "", "client_version": "1.0.0"},
+        {"username": "testuser", "password": "testpassword123", "client_version": ""},
+        {"username": "", "password": "", "client_version": ""},
+    ],
+)
+async def test_client_enroll_empty_fields(client: AsyncClient, enroll_data):
     """Test enrollment with empty string fields"""
-    enroll_data = {
-        "username": "",
-        "password": "",
-        "client_version": ""
-    }
-
     response = await client.post("/client/auth/enroll", json=enroll_data)
-    # This should still work from a validation perspective, but might want to add business logic validation
-    assert response.status_code in [200, 422]  # Depends on if you add validation for empty strings
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add min-length validation to enrollment and login request schemas
- parametrize empty-field enrollment tests and require 422 response

## Testing
- `pytest server/backend/tests/unit/test_routers/test_client_auth.py::test_client_enroll_empty_fields -q`