### PR TITLE
chore: enforce frontend formatting

### DIFF
--- a/server/frontend/src/App.tsx
+++ b/server/frontend/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
         }/>
       </Routes>
     </BrowserRouter>
-  )
+  );
 }
 
 export default App;

--- a/server/frontend/src/apiClient.ts
+++ b/server/frontend/src/apiClient.ts
@@ -43,7 +43,7 @@ class ApiClient {
         return {
           statusCode: response.status,
           message: response.statusText,
-        }
+        };
       }
 
       return await response.json() as T;

--- a/server/frontend/src/componets/AuthForm.tsx
+++ b/server/frontend/src/componets/AuthForm.tsx
@@ -54,7 +54,7 @@ export default function AuthForm({
       const success = await onSubmit(formData);
       if (success) {
         if (successRedirectPath === '/dashboard') {
-          setUser({ username: formData.username })
+          setUser({ username: formData.username });
           const from = location.state?.from?.pathname || '/dashboard';
           navigate(from, { replace: true });
         } else {

--- a/server/frontend/src/main.tsx
+++ b/server/frontend/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);

--- a/server/frontend/src/stores/authStore.ts
+++ b/server/frontend/src/stores/authStore.ts
@@ -24,4 +24,4 @@ export const useAuthStore = create<AuthState>()(
       name: 'auth-storage'
     }
   )
-)
+);


### PR DESCRIPTION
## Summary
- add missing semicolons across frontend source
- clean up auth store and API client syntax

## Testing
- `npm test` *(fails: Expected true Received false)*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68ae122f1e748321b4d53d64435f4155