### PR TITLE
refactor: allow MainSkeleton to accept children

### DIFF
--- a/server/frontend/src/components/ClientPage.tsx
+++ b/server/frontend/src/components/ClientPage.tsx
@@ -27,6 +27,10 @@ export default function ClientPage({ username }: ClientPageProps) {
     fetchClientInfo();
   }, [username, navigate]);
 
-  const clientPageContents = <div>Hello World</div>
-  return <MainSkeleton baseName={"Client " + username} baseContents={clientPageContents} />;
+  const clientPageContents = <div>Hello World</div>;
+  return (
+    <MainSkeleton baseName={"Client " + username}>
+      {clientPageContents}
+    </MainSkeleton>
+  );
 }

--- a/server/frontend/src/components/Dashboard.tsx
+++ b/server/frontend/src/components/Dashboard.tsx
@@ -117,5 +117,9 @@ export default function Dashboard() {
     </div>
   );
 
-  return <MainSkeleton baseName="Dashboard" baseContents={dashboardContents} />;
+  return (
+    <MainSkeleton baseName="Dashboard">
+      {dashboardContents}
+    </MainSkeleton>
+  );
 }

--- a/server/frontend/src/components/MainSkeleton.tsx
+++ b/server/frontend/src/components/MainSkeleton.tsx
@@ -4,10 +4,10 @@ import React from "react";
 
 interface MainSkeletonProps {
   baseName: string;
-  baseContents: React.ReactNode;
+  children: React.ReactNode;
 }
 
-export default function MainSkeleton({ baseName, baseContents }: MainSkeletonProps) {
+export default function MainSkeleton({ baseName, children }: MainSkeletonProps) {
   return (
     <div className="min-h-screen bg-gray-100 dark:bg-gray-900">
       <aside
@@ -28,7 +28,7 @@ export default function MainSkeleton({ baseName, baseContents }: MainSkeletonPro
         </header>
 
         <main className="p-6">
-          {baseContents}
+          {children}
         </main>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow `MainSkeleton` to render `children` instead of `baseContents`
- update consumers to pass page content via children