### PR TITLE
Replace HTTPException status constants with integers

### DIFF
--- a/server/backend/app/routes/client.py
+++ b/server/backend/app/routes/client.py
@@ -6,7 +6,6 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from starlette import status
 
 from app.dependencies import get_db
 from app.models.client import Client
@@ -36,7 +35,7 @@ async def client(username: str, db: AsyncSession = Depends(get_db), _=Depends(au
         )
 
     raise HTTPException(
-        status_code=status.HTTP_404_NOT_FOUND,
+        status_code=404,
         detail="Client not found"
     )
 
@@ -70,7 +69,7 @@ async def client_all(db: AsyncSession = Depends(get_db), _=Depends(authenticatio
 async def client_update(client: Client = Depends(get_current_client)):
     if client.client_version >= settings.version:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=400,
             detail="Client already at latest version"
         )
 
@@ -78,7 +77,7 @@ async def client_update(client: Client = Depends(get_current_client)):
     client_binary = Path(settings.client_directory) / "target" / f"client{client_binary_ext}"
     if not os.path.isfile(client_binary):
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=500,
             detail="Unable to find client binary"
         )
 
@@ -104,6 +103,6 @@ async def client_update_info(update_info: ClientUpdateInfo,
     except Exception:
         await db.rollback()
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=500,
             detail="Failed to add updated information to the database"
         )

--- a/server/backend/app/routes/user_auth.py
+++ b/server/backend/app/routes/user_auth.py
@@ -3,7 +3,6 @@ from datetime import datetime, UTC
 from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from starlette import status
 
 from app.dependencies import get_db
 from app.models.user import User
@@ -31,7 +30,7 @@ async def user_auth_register(signup_request: UserSignupRequest, db: AsyncSession
     """
     existing_user = await db.execute(select(User).where(User.username == signup_request.username))
     if existing_user.scalar_one_or_none():
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Username already exists")
+        raise HTTPException(status_code=409, detail="Username already exists")
 
     new_user = User(
         username=signup_request.username,
@@ -45,7 +44,7 @@ async def user_auth_register(signup_request: UserSignupRequest, db: AsyncSession
 
     except Exception:
         await db.rollback()
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        raise HTTPException(status_code=500,
                             detail="Failed to add user to the database")
 
 
@@ -71,7 +70,7 @@ async def user_auth_login(signin_request: UserSigninRequest, response: Response,
     user = user.scalar_one_or_none()
 
     if not user or not user.verify_password(signin_request.password):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid username or password")
+        raise HTTPException(status_code=401, detail="Invalid username or password")
 
     try:
         access_token = create_access_token(user.uuid, True)
@@ -85,7 +84,7 @@ async def user_auth_login(signin_request: UserSigninRequest, response: Response,
         raise e
     except Exception:
         await db.rollback()
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        raise HTTPException(status_code=500,
                             detail="Failed to sign in user")
 
 

--- a/server/backend/app/services/user_websockets.py
+++ b/server/backend/app/services/user_websockets.py
@@ -5,7 +5,6 @@ from typing import Dict, Set
 from fastapi import WebSocket
 
 from app.logger import get_logger
-from app.routes.user_auth import user_auth_login
 
 log = get_logger()
 


### PR DESCRIPTION
## Summary
- replace FastAPI status constants with literal integers in backend HTTPException usages
- drop unused imports that were only needed for status constants or no longer referenced

## Testing
- ruff check --select F401 app

------
https://chatgpt.com/codex/tasks/task_e_68c8a481c2fc8321a055a91a5114e0f3